### PR TITLE
Atualiza scripts de setup para libs

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -25,17 +25,43 @@ IF ERRORLEVEL 1 (
     EXIT /B 1
 )
 
-echo [4/5] Instalando dependências do requirements.txt...
+echo [4/6] Instalando dependências do requirements.txt...
 IF EXIST requirements.txt (
     pip install -r requirements.txt
     IF ERRORLEVEL 1 (
         echo Erro ao instalar dependências.
         EXIT /B 1
     )
-    echo [5/5] Dependências instaladas com sucesso.
 ) ELSE (
     echo Arquivo requirements.txt não encontrado. Nenhuma dependência instalada.
 )
 
-echo ✅ Setup concluído com sucesso.
+:: Diretório que contém as bibliotecas obrigatórias
+SET LIBS_DIR=libs
+
+echo [5/6] Instalando dependências das bibliotecas...
+FOR %%L IN (NIST MDmisc PMlib WSQ) DO (
+    IF EXIST "%LIBS_DIR%\%%L\requirements.txt" (
+        echo Instalando dependencias de %LIBS_DIR%\%%L\requirements.txt...
+        pip install -r "%LIBS_DIR%\%%L\requirements.txt"
+        IF ERRORLEVEL 1 (
+            echo Erro ao instalar dependencias de %LIBS_DIR%\%%L.
+            EXIT /B 1
+        )
+    )
+)
+
+:: Cria arquivo .pth apontando para as bibliotecas
+FOR /F "delims=" %%p IN ('python -c "import site; print(site.getsitepackages()[0])"') DO SET SITE_PACKAGES=%%p
+SET PTH_FILE=%SITE_PACKAGES%\mdedonno.pth
+echo Criando %PTH_FILE%...
+( 
+    echo %CD%\libs\NIST
+    echo %CD%\libs\WSQ
+    echo %CD%\libs\PMlib
+    echo %CD%\libs\MDmisc
+) > "%PTH_FILE%"
+echo %PTH_FILE% criado.
+
+echo [6/6] Setup concluído com sucesso.
 ENDLOCAL

--- a/setup.sh
+++ b/setup.sh
@@ -34,11 +34,15 @@ else
     echo "⚠️ Arquivo requirements.txt não encontrado. Nenhuma dependência instalada."
 fi
 
+# Diretório contendo as bibliotecas obrigatórias
+LIBS_DIR="./libs"
+
 # Instala dependências das bibliotecas auxiliares
 for lib in NIST MDmisc PMlib WSQ; do
-    if [ -f "$lib/requirements.txt" ]; then
-        echo "➡️ Instalando dependências de $lib/requirements.txt..."
-        pip install -r "$lib/requirements.txt"
+    LIB_PATH="$LIBS_DIR/$lib"
+    if [ -f "$LIB_PATH/requirements.txt" ]; then
+        echo "➡️ Instalando dependências de $LIB_PATH/requirements.txt..."
+        pip install -r "$LIB_PATH/requirements.txt"
     fi
 done
 
@@ -51,7 +55,12 @@ EOF
 PTH_FILE="$SITE_PACKAGES/mdedonno.pth"
 
 echo "➡️ Criando $PTH_FILE..."
-printf "%s\n" "$(pwd)/NIST" "$(pwd)/WSQ" "$(pwd)/PMlib" "$(pwd)/MDmisc" > "$PTH_FILE"
+printf "%s\n" \
+    "$(pwd)/libs/NIST" \
+    "$(pwd)/libs/WSQ" \
+    "$(pwd)/libs/PMlib" \
+    "$(pwd)/libs/MDmisc" \
+    > "$PTH_FILE"
 echo "✅ $PTH_FILE criado."
 
 echo "✅ Setup concluído com sucesso."


### PR DESCRIPTION
## Summary
- atualizar setup.sh pra instalar libs dentro de `libs/`
- ajustar setup.bat com mesmo procedimento e criação do arquivo `.pth`

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in libs/NIST/doctester.py)*

------
https://chatgpt.com/codex/tasks/task_e_686742103f80833296d0def86ece7894