### PR TITLE
Update python path example in docs

### DIFF
--- a/libs/NIST/doc/Installation.rst
+++ b/libs/NIST/doc/Installation.rst
@@ -55,7 +55,7 @@ The structure of the files should be as follows:
 
 .. code-block:: bash
 
-   $ cat /usr/local/lib/python2.7/dist-packages/mdedonno.pth
+   $ cat /usr/local/lib/python3.x/dist-packages/mdedonno.pth
    /library/NIST
    /library/WSQ
    /library/PMlib


### PR DESCRIPTION
## Summary
- update Installation docs to show Python 3.x site-packages path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867519052048332a8540f015a968b1a