### PR TITLE
Fix memory IO for binary data

### DIFF
--- a/libs/MDmisc/MDmisc/ZipFile.py
+++ b/libs/MDmisc/MDmisc/ZipFile.py
@@ -4,7 +4,7 @@
 
 
 import zipfile
-from io import StringIO as io
+from io import BytesIO as io
 
 class ZipFileExtended( zipfile.ZipFile ):
     def removeFile( self, *filenames ):

--- a/libs/MDmisc/MDmisc/objmanipulate.py
+++ b/libs/MDmisc/MDmisc/objmanipulate.py
@@ -2,36 +2,37 @@
 # -*- coding: UTF-8 -*-
 
 import base64
-from io import StringIO
+from io import BytesIO
 import gzip
 import pickle
 
 
 def objectToPickle( obj ):
-    fp = StringIO()
+    fp = BytesIO()
     pickle.dump( obj, fp )
-    
+
     return fp.getvalue()
 
 def pickleToObject( p ):
-    fp = StringIO()
+    fp = BytesIO()
     fp.write( p )
     fp.seek( 0 )
     
     return pickle.load( fp )
 
 def compress( obj ):
-    zip_text_file = StringIO()
-      
+    zip_text_file = BytesIO()
+
     zipper = gzip.GzipFile( mode = 'wb', fileobj = zip_text_file )
-      
+
+    # obj is expected to be bytes
     zipper.write( obj )
     zipper.close()
-      
+
     return base64.b64encode( zip_text_file.getvalue() )
 
 def decompress( data ):
-    sample_text_file = gzip.GzipFile( mode = 'rb', fileobj = StringIO( base64.b64decode( data ) ) )
+    sample_text_file = gzip.GzipFile( mode = 'rb', fileobj = BytesIO( base64.b64decode( data ) ) )
     ret = sample_text_file.read()
     sample_text_file.close()
     
@@ -44,5 +45,5 @@ def compressedToObject( data ):
     return pickleToObject( decompress( data ) )
 
 def decompressPickleFromFile( f ):
-    with open( f ) as fp:
+    with open( f, 'rb' ) as fp:
         return compressedToObject( fp.read() )


### PR DESCRIPTION
## Summary
- use `BytesIO` instead of `StringIO` for binary serialization helpers
- open files in binary mode when reading compressed pickles

## Testing
- `pytest -q`
- `python -m py_compile libs/MDmisc/MDmisc/objmanipulate.py libs/MDmisc/MDmisc/ZipFile.py`


------
https://chatgpt.com/codex/tasks/task_e_6867529047b08332ba25e14360efd0a2