### PR TITLE
Fix duplicate import

### DIFF
--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -23,7 +23,6 @@ from MDmisc.string import join, upper, stringIterator, split_r
 
 from .binary import binary_fields
 from .config import RS, US
-from .config import RS, US
 from .exceptions import *
 from .functions import bindump, default_origin, get_label, decode_fgp, encode_fgp
 from .voidType import voidType


### PR DESCRIPTION
## Summary
- remove duplicate import in `NIST.core.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686751fef3f0833286c3c9a8a7a33906