### PR TITLE
Atualiza compatibilidade para Python 3.12

### DIFF
--- a/libs/MDmisc/MDmisc/elist.py
+++ b/libs/MDmisc/MDmisc/elist.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: UTF-8 -*-
 
-import collections
+from collections.abc import Iterable
 
 from .map_r import map_r
 
@@ -16,7 +16,7 @@ def replace_r( x, s, r ):
 
 def flatten( lst ):
     for e in lst:
-        if isinstance( e, collections.Iterable ) and not isinstance( e, str ):
+        if isinstance( e, Iterable ) and not isinstance( e, str ):
             for sublist in flatten( e ):
                 yield sublist
         else:

--- a/libs/MDmisc/MDmisc/string.py
+++ b/libs/MDmisc/MDmisc/string.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: UTF-8 -*-
 
-import collections
+from collections.abc import Mapping, Iterable
 import unicodedata
 
 def upper( data ):
@@ -130,18 +130,19 @@ def split_no_empty( data, string ):
     """
     return [ value for value in data.split( string ) if value != "" ]
 
+
 def unicode2str( data ):
-    if type( data ) == str:
+    if isinstance( data, str ):
         return data
-     
-    elif type( data ) == str:
-        return str( data.encode( 'utf-8', 'ignore' ).strip() )
-    
-    elif isinstance( data, collections.Mapping ):
-        return dict( list(map( unicode2str, iter(list(data.items())) )) )
-    
-    elif isinstance( data, collections.Iterable ):
-        return type( data )( list(map( unicode2str, data )) )
+
+    elif isinstance( data, bytes ):
+        return data.decode( 'utf-8', 'ignore' ).strip()
+
+    elif isinstance( data, Mapping ):
+        return dict( map( unicode2str, data.items() ) )
+
+    elif isinstance( data, Iterable ):
+        return type( data )( map( unicode2str, data ) )
     
     else:
         return data


### PR DESCRIPTION
## Summary
- update `string.py` and `elist.py` to use `collections.abc`
- tweak `unicode2str` implementation for Python 3

## Testing
- `python3.12 -m py_compile libs/MDmisc/MDmisc/string.py libs/MDmisc/MDmisc/elist.py`


------
https://chatgpt.com/codex/tasks/task_e_686757558c38833296969004d92289fb