### PR TITLE
Atualiza setup para usar install_nist.py

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -51,17 +51,13 @@ FOR %%L IN (NIST MDmisc PMlib WSQ) DO (
     )
 )
 
-:: Cria arquivo .pth apontando para as bibliotecas
-FOR /F "delims=" %%p IN ('python -c "import site; print(site.getsitepackages()[0])"') DO SET SITE_PACKAGES=%%p
-SET %PTH_FILE%=%SITE_PACKAGES%\mdedonno.pth
-echo Criando %PTH_FILE%...
-( 
-    echo %CD%\libs\NIST
-    echo %CD%\libs\WSQ
-    echo %CD%\libs\PMlib
-    echo %CD%\libs\MDmisc
-) > "%PTH_FILE%"
-echo %PTH_FILE% criado.
+:: Instala bibliotecas da pasta libs no ambiente virtual
+echo Executando install_nist.py...
+python install_nist.py %VENV_DIR% %LIBS_DIR%/
+IF ERRORLEVEL 1 (
+    echo Erro ao executar install_nist.py.
+    EXIT /B 1
+)
 
 echo [6/6] Setup concluído com sucesso.
 ENDLOCAL

--- a/setup.sh
+++ b/setup.sh
@@ -44,23 +44,12 @@ for lib in NIST MDmisc PMlib WSQ; do
         echo "➡️ Instalando dependências de $LIB_PATH/requirements.txt..."
         pip install -r "$LIB_PATH/requirements.txt"
     fi
+
 done
 
-# Cria arquivo .pth para tornar as bibliotecas visíveis ao Python
-SITE_PACKAGES=$(python - <<'EOF'
-import site
-print(site.getsitepackages()[0])
-EOF
-)
-PTH_FILE="$SITE_PACKAGES/mdedonno.pth"
-
-echo "➡️ Criando $PTH_FILE..."
-printf "%s\n" \
-    "$(pwd)/libs/NIST" \
-    "$(pwd)/libs/WSQ" \
-    "$(pwd)/libs/PMlib" \
-    "$(pwd)/libs/MDmisc" \
-    > "$PTH_FILE"
-echo "✅ $PTH_FILE criado."
+# Instala bibliotecas da pasta libs no ambiente virtual
+echo "➡️ Instalando bibliotecas auxiliares no ambiente virtual..."
+python install_nist.py "$VENV_DIR" "$LIBS_DIR/"
+echo "✅ Bibliotecas auxiliares instaladas."
 
 echo "✅ Setup concluído com sucesso."


### PR DESCRIPTION
## Summary
- use the new install_nist.py script in setup.sh
- use install_nist.py in setup.bat
- remove direct .pth file creation logic

## Testing
- `bash -n setup.sh`
- `python install_nist.py venv libs/ | head -n 2`

------
https://chatgpt.com/codex/tasks/task_e_6867666879008332904b0622cc03bb5e