### PR TITLE
Fix Callable import

### DIFF
--- a/libs/MDmisc/MDmisc/DefaultOrderedDict.py
+++ b/libs/MDmisc/MDmisc/DefaultOrderedDict.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 #  *-* coding: utf-8 *-*
 
-from collections import OrderedDict, Callable
+from collections import OrderedDict
+from collections.abc import Callable
 
 class DefaultOrderedDict( OrderedDict ):
     # Source: http://stackoverflow.com/a/6190500/562769


### PR DESCRIPTION
## Summary
- fix import for `Callable` in `DefaultOrderedDict`

## Testing
- `python -m compileall -q libs/MDmisc/MDmisc/DefaultOrderedDict.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676b816d3c8332b7a3679c70158786