### PR TITLE
Update collections imports

### DIFF
--- a/libs/MDmisc/MDmisc/edict.py
+++ b/libs/MDmisc/MDmisc/edict.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-import collections
 
 class edict( dict ):
     def reverse( self ):

--- a/libs/MDmisc/MDmisc/string.py
+++ b/libs/MDmisc/MDmisc/string.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-import collections
+import collections.abc as collections
 import unicodedata
 
 def upper( data ):


### PR DESCRIPTION
## Summary
- use `collections.abc` namespace in `string.py`
- remove unused collections import in `edict.py`

## Testing
- `python -m compileall -q libs/MDmisc/MDmisc` *(fails: SyntaxError in progressbar.py)*
- `python -m pip check`
- `python - <<'PY'
from libs.MDmisc.MDmisc import string
from libs.MDmisc.MDmisc import edict
print(string.unicode2str({'a': 'b'}))
ed = edict.edict({'a': 1, 'b': 2})
print(ed.get('a'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68676b9b38e08332b3b91b0129387cda