### PR TITLE
Fix Python3 parsing issues

### DIFF
--- a/libs/MDmisc/MDmisc/binary.py
+++ b/libs/MDmisc/MDmisc/binary.py
@@ -28,12 +28,13 @@ def int_to_bin( x, digits = 0 ):
         '00000000000000000000010100111001'
     """
 
-    oct2bin = [ '000', '001', '010', '011', '100', '101', '110', '111' ] 
-    binstring = [ oct2bin[int( n )] for n in oct( x ) ]
-    binstring = ''.join( binstring ).lstrip( '0' )
-    
+    oct2bin = [ '000', '001', '010', '011', '100', '101', '110', '111' ]
+    octstr = oct( x )[ 2: ]
+    binstring = ''.join( oct2bin[ int( n ) ] for n in octstr )
+    binstring = binstring.lstrip( '0' )
+
     if digits == 'up':
-        digits = 8 * ( len( binstring ) / 8 + 1 )
+        digits = 8 * ( len( binstring ) // 8 + 1 )
         
     return binstring.zfill( digits ) 
 

--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -171,12 +171,17 @@ class NIST( object ):
     
         with open( infile, "rb" ) as fp:
             data = fp.read()
-        
-        if data[ 0 ] == "{" and data[ -1 ] == "}":
-            self.from_json( data )
-        
+
+        if isinstance( data, bytes ):
+            decoded = data.decode( 'latin-1' )
         else:
-            self.load( data )
+            decoded = data
+
+        if decoded and decoded[ 0 ] == "{" and decoded[ -1 ] == "}":
+            self.from_json( decoded )
+
+        else:
+            self.load( decoded )
     
     def process_fileContent( self, data ):
         """
@@ -198,10 +203,10 @@ class NIST( object ):
                 [2, 4, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19, 20, 20, 21, 21, 98, 99]
         """
         try:
-            data = map( lambda x: map( int, x.split( US ) ), data.split( RS ) )
-        except:
+            data = [ list( map( int, x.split( US ) ) ) for x in data.split( RS ) ]
+        except Exception:
             data = replace_r( split_r( [ RS, US ], data ), '', '1' )
-            data = map_r( int, data )
+            data = list( map_r( int, data ) )
         
         self.nbLogicalRecords = data[ 0 ][ 1 ]
         

--- a/libs/NIST/NIST/traditional/__init__.py
+++ b/libs/NIST/NIST/traditional/__init__.py
@@ -34,10 +34,16 @@ class NIST( NIST_Core ):
                 self.read( p )
         
         elif isinstance( p, BytesIO ):
-            self.load( p.getvalue() )
+            data = p.getvalue()
+            if isinstance( data, bytes ):
+                data = data.decode( 'latin-1' )
+            self.load( data )
 
         elif isinstance( p, IOBase ):
-            self.load( p.read() )
+            data = p.read()
+            if isinstance( data, bytes ):
+                data = data.decode( 'latin-1' )
+            self.load( data )
         
         elif isinstance( p, ( NIST, dict ) ):
             if isinstance( p, NIST ):
@@ -66,6 +72,9 @@ class NIST( NIST_Core ):
             :type data: str
         """
         debug.debug( "Loading object" )
+
+        if isinstance( data, bytes ):
+            data = data.decode( 'latin-1' )
         
         records = data.split( FS )
         


### PR DESCRIPTION
## Summary
- handle bytes from file reads and streams
- fix process_fileContent for iterables
- update binary helpers for Python3

## Testing
- `PYTHONPATH=../MDmisc:../PMlib:.. python doctester.py` *(fails: TypeError: 'map' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_6867bc46bbcc833285abed7b9acbf526