### PR TITLE
Fix hashing and write operations for Python3

### DIFF
--- a/libs/NIST/NIST/traditional/__init__.py
+++ b/libs/NIST/NIST/traditional/__init__.py
@@ -260,11 +260,11 @@ class NIST( NIST_Core ):
             os.makedirs( os.path.dirname( os.path.realpath( outfile ) ) )
         
         with open( outfile, "wb+" ) as fp:
-            fp.write( self.dumpbin() )
+            fp.write( self.dumpbin().encode('latin-1') )
     
     def hash( self ):
 
-        return hashlib.md5( self.dumpbin() ).hexdigest()
+        return hashlib.md5( self.dumpbin().encode('latin-1') ).hexdigest()
     
     ############################################################################
     # 


### PR DESCRIPTION
## Summary
- ensure binary dumps are encoded when writing
- encode dump before hashing to avoid type error

## Testing
- `python -m pip install pillow`
- `python - <<'PY'
from libs.NIST.NIST import NIST
n = NIST.NIST()
n.read('libs/NIST/sample/type-1.an2')
print(str(n)[:60])
print(n.hash()[:10])
PY
` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6867bdfbbe208332b0af05d670a0e700