### PR TITLE
Fix hashing with mixed dump types

### DIFF
--- a/libs/MDmisc/__init__.py
+++ b/libs/MDmisc/__init__.py
@@ -1,2 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# Expose modules from the nested 'MDmisc' package at the top level so that
+# imports such as ``MDmisc.deprecated`` work without modifying ``sys.path``.
+# Re-export common helpers from the nested ``MDmisc`` package.  This mirrors the
+# historical layout expected by code in :mod:`NIST` which imports modules such as
+# ``MDmisc.deprecated`` directly from this package.
+import os
+
+# Include the nested ``MDmisc`` directory in the package search path so that
+# modules like ``MDmisc.boxer`` can be resolved correctly.
+__path__.append(os.path.join(os.path.dirname(__file__), 'MDmisc'))
+
+from .MDmisc.deprecated import deprecated  # noqa:F401

--- a/libs/NIST/NIST/traditional/__init__.py
+++ b/libs/NIST/NIST/traditional/__init__.py
@@ -264,7 +264,11 @@ class NIST( NIST_Core ):
     
     def hash( self ):
 
-        return hashlib.md5( self.dumpbin().encode('latin-1') ).hexdigest()
+        dump = self.dumpbin()
+        if isinstance( dump, str ):
+            dump = dump.encode('latin-1')
+
+        return hashlib.md5( dump ).hexdigest()
     
     ############################################################################
     # 


### PR DESCRIPTION
## Summary
- handle bytes/str dumps when hashing
- expose nested MDmisc modules so imports work

## Testing
- `pip install -r libs/NIST/requirements.txt`
- `python libs/NIST/doctester.py` *(fails: TypeError 'map' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_6867bf9ddb68833283630bb002902179