### PR TITLE
Fix map iterator issues

### DIFF
--- a/libs/MDmisc/MDmisc/string.py
+++ b/libs/MDmisc/MDmisc/string.py
@@ -87,8 +87,12 @@ def split_r( lst, s ):
             [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
     """
     try:
-        return map( lambda x: split_r( lst[ 1: ], x ), s.split( lst[ 0 ] ) )
-    except:
+        # ``map`` returned a list in Python 2, but an iterator in Python 3.
+        # The callers of :func:`split_r` expect a nested list structure and
+        # often index into the result, so we materialise the result explicitly
+        # as a list.
+        return [ split_r( lst[1:], x ) for x in s.split( lst[0] ) ]
+    except Exception:
         return s
 
 class stringIterator( object ):

--- a/libs/NIST/NIST/core/functions.py
+++ b/libs/NIST/NIST/core/functions.py
@@ -221,7 +221,11 @@ def encode_fgp( code, separator = "/" ):
         code = code.split( separator )
         
     # Cast all values to integer
-    code = map( int, code )
+    # Cast all values to integers. ``map`` returns an iterator in Python 3,
+    # but the resulting sequence is needed multiple times below (iteration,
+    # extending and slicing). Materialise it as a list to avoid exhaustion and
+    # to support list operations.
+    code = list(map(int, code))
     
     # Check for the min (0) and max value (14)
     for v in code:


### PR DESCRIPTION
## Summary
- fix encode_fgp for Python 3 `map` behaviour
- return list from `split_r` helper

## Testing
- `pip install -r requirements.txt`
- `python libs/NIST/doctester.py` *(fails: doctest failures)*

------
https://chatgpt.com/codex/tasks/task_e_6867c8cc47ec8332b09632dc9ab307be