### PR TITLE
Fix clean method loops

### DIFF
--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -1004,11 +1004,11 @@ class NIST( object ):
         debug.debug( "Cleaning the NIST object" )
         
         #     Delete all empty data.
-        for ntype in self.get_ntype():
-            for idc in self.data[ ntype ].keys():
+        for ntype in list( self.get_ntype() ):
+            for idc in list( self.data[ ntype ].keys() ):
                 
                 #    Fields
-                for tagid in self.data[ ntype ][ idc ].keys():
+                for tagid in list( self.data[ ntype ][ idc ].keys() ):
                     value = self.get_field( "%d.%03d" % ( ntype, tagid ), idc )
                     if value == "" or value == None:
                         debug.debug( "Field %02d.%03d IDC %d deleted" % ( ntype, tagid, idc ), 1 )


### PR DESCRIPTION
## Summary
- prevent dictionary mutation errors when cleaning NIST objects
- iterate over copies of keys in `NIST.clean`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867cca4bd848332a1c6d3ff74435aef