### PR TITLE
Add encoding option when writing NIST files

### DIFF
--- a/create_nist.py
+++ b/create_nist.py
@@ -45,7 +45,7 @@ with open(f'amostras\digitais\digital_1.wsq', 'rb') as f:
     digital = f.read()
     new_nist.set_field('4.999', digital, idc=1)
 
-# Salva o nist no disco
-new_nist.write('novo_nist.nst')
+# Salva o nist no disco usando UTF-8
+new_nist.write('novo_nist.nst', encoding='utf-8')
 
 print(new_nist)

--- a/libs/NIST/NIST/traditional/__init__.py
+++ b/libs/NIST/NIST/traditional/__init__.py
@@ -247,26 +247,28 @@ class NIST( NIST_Core ):
         
         return "".join( outnist )
 
-    def write( self, outfile ):
+    def write( self, outfile, encoding="latin-1" ):
         """
             Write the NIST object to a specific file.
-            
+
             :param outfile: URI of the file to write to.
             :type outfile: str
+            :param encoding: Character encoding used when writing textual fields.
+            :type encoding: str
         """
-        debug.debug( "Write the NIST object to '%s'" % outfile )
-        
+        debug.debug( "Write the NIST object to '%s' using %s encoding" % ( outfile, encoding ) )
+
         if not os.path.isdir( os.path.dirname( os.path.realpath( outfile ) ) ):
             os.makedirs( os.path.dirname( os.path.realpath( outfile ) ) )
-        
+
         with open( outfile, "wb+" ) as fp:
-            fp.write( self.dumpbin().encode('latin-1') )
-    
-    def hash( self ):
+            fp.write( self.dumpbin().encode( encoding ) )
+
+    def hash( self, encoding="latin-1" ):
 
         dump = self.dumpbin()
         if isinstance( dump, str ):
-            dump = dump.encode('latin-1')
+            dump = dump.encode( encoding )
 
         return hashlib.md5( dump ).hexdigest()
     


### PR DESCRIPTION
## Summary
- allow specifying an encoding when writing NIST objects
- use UTF‑8 encoding in the demo script

## Testing
- `flake8 create_nist.py libs/NIST/NIST/traditional/__init__.py`
- `pip install -r requirements.txt`
- `PYTHONPATH=libs:libs/PMlib python3 create_nist.py` *(fails: ModuleNotFoundError: No module named 'NIST.NIST.traditional.functions')*

------
https://chatgpt.com/codex/tasks/task_e_6867d460b58c8332865bd81232d50e5b