### PR TITLE
Fix UTF-8 handling in NIST writer

### DIFF
--- a/create_nist.py
+++ b/create_nist.py
@@ -20,7 +20,7 @@ new_nist.set_field('2.202', 'MÃE DA ROBERTS', idc=0)  # Mae
 
 # Faces
 faces = [
-    r'amostras\fotos\JuliaRoberts7.jpg'
+    'amostras/fotos/JuliaRoberts.jfif'
 ]
 new_nist.add_ntype(10)
 for index, face in enumerate(faces, start=1):
@@ -29,21 +29,21 @@ for index, face in enumerate(faces, start=1):
         new_nist.set_field('10.999', face, idc=index)
 
 # Digitais
-new_nist.add_ntype(4)
-new_nist.set_field('4.001', 4, idc=1)  # Record Type (TYP) [Mandatory]
-new_nist.set_field('4.002', 0, idc=1)  # Image Designation Character (IDC) [Mandatory]
-new_nist.set_field('4.003', 1, idc=1)  # Impression Type (IMP) [Mandatory]
-new_nist.set_field('4.004', 1, idc=1)  # Image Horizontal Line Length (HLL) [Mandatory]
-new_nist.set_field('4.005', 1, idc=1)  # Image Vertical Line Length (VLL) [Mandatory]
-new_nist.set_field('4.006', 800, idc=1)  # Fingerprint Image Scanning Resolution (FIR) [Mandatory]
-new_nist.set_field('4.007', 750, idc=1)  # Finger Position (FGP) [Mandatory]
-new_nist.set_field('4.008', 1, idc=1)  # Print Position Coordinates (PPC) [Optional]
-new_nist.set_field('4.014', 'WSQ', idc=1)  # Image Compression Algorithm (ICA) [Mandatory]
-
-# Adiciona o dedo plegar direito (idc=1)
-with open(f'amostras\digitais\digital_1.wsq', 'rb') as f:
-    digital = f.read()
-    new_nist.set_field('4.999', digital, idc=1)
+# new_nist.add_ntype(4)
+# new_nist.set_field('4.001', 4, idc=1)  # Record Type (TYP) [Mandatory]
+# new_nist.set_field('4.002', 0, idc=1)  # Image Designation Character (IDC) [Mandatory]
+# new_nist.set_field('4.003', 1, idc=1)  # Impression Type (IMP) [Mandatory]
+# new_nist.set_field('4.004', 1, idc=1)  # Image Horizontal Line Length (HLL) [Mandatory]
+# new_nist.set_field('4.005', 1, idc=1)  # Image Vertical Line Length (VLL) [Mandatory]
+# new_nist.set_field('4.006', 800, idc=1)  # Fingerprint Image Scanning Resolution (FIR) [Mandatory]
+# new_nist.set_field('4.007', 750, idc=1)  # Finger Position (FGP) [Mandatory]
+# new_nist.set_field('4.008', 1, idc=1)  # Print Position Coordinates (PPC) [Optional]
+# new_nist.set_field('4.014', 'WSQ', idc=1)  # Image Compression Algorithm (ICA) [Mandatory]
+# 
+# # Adiciona o dedo plegar direito (idc=1)
+# # with open(f'amostras\digitais\digital_1.wsq', 'rb') as f:
+# #     digital = f.read()
+#     new_nist.set_field('4.999', digital, idc=1)
 
 # Salva o nist no disco
 new_nist.write('novo_nist.nst')

--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -173,7 +173,7 @@ class NIST( object ):
             data = fp.read()
 
         if isinstance( data, bytes ):
-            decoded = data.decode( 'latin-1' )
+            decoded = data.decode( 'utf-8' )
         else:
             decoded = data
 

--- a/libs/NIST/NIST/traditional/__init__.py
+++ b/libs/NIST/NIST/traditional/__init__.py
@@ -36,13 +36,13 @@ class NIST( NIST_Core ):
         elif isinstance( p, BytesIO ):
             data = p.getvalue()
             if isinstance( data, bytes ):
-                data = data.decode( 'latin-1' )
+                data = data.decode( 'utf-8' )
             self.load( data )
 
         elif isinstance( p, IOBase ):
             data = p.read()
             if isinstance( data, bytes ):
-                data = data.decode( 'latin-1' )
+                data = data.decode( 'utf-8' )
             self.load( data )
         
         elif isinstance( p, ( NIST, dict ) ):
@@ -74,7 +74,7 @@ class NIST( NIST_Core ):
         debug.debug( "Loading object" )
 
         if isinstance( data, bytes ):
-            data = data.decode( 'latin-1' )
+            data = data.decode( 'utf-8' )
         
         records = data.split( FS )
         
@@ -260,13 +260,13 @@ class NIST( NIST_Core ):
             os.makedirs( os.path.dirname( os.path.realpath( outfile ) ) )
         
         with open( outfile, "wb+" ) as fp:
-            fp.write( self.dumpbin().encode('latin-1') )
+            fp.write( self.dumpbin().encode('utf-8') )
     
     def hash( self ):
 
         dump = self.dumpbin()
         if isinstance( dump, str ):
-            dump = dump.encode('latin-1')
+            dump = dump.encode('utf-8')
 
         return hashlib.md5( dump ).hexdigest()
     


### PR DESCRIPTION
## Summary
- ensure library reads and writes NIST data using UTF-8
- update `create_nist.py` to use an existing sample image and disable missing fingerprint data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d841899c833284c291d35929f652