### PR TITLE
Update encoding handling to latin-1

### DIFF
--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -173,7 +173,7 @@ class NIST( object ):
             data = fp.read()
 
         if isinstance( data, bytes ):
-            decoded = data.decode( 'utf-8' )
+            decoded = data.decode( 'latin-1' )
         else:
             decoded = data
 

--- a/libs/NIST/NIST/traditional/__init__.py
+++ b/libs/NIST/NIST/traditional/__init__.py
@@ -36,13 +36,13 @@ class NIST( NIST_Core ):
         elif isinstance( p, BytesIO ):
             data = p.getvalue()
             if isinstance( data, bytes ):
-                data = data.decode( 'utf-8' )
+                data = data.decode( 'latin-1' )
             self.load( data )
 
         elif isinstance( p, IOBase ):
             data = p.read()
             if isinstance( data, bytes ):
-                data = data.decode( 'utf-8' )
+                data = data.decode( 'latin-1' )
             self.load( data )
         
         elif isinstance( p, ( NIST, dict ) ):
@@ -74,7 +74,7 @@ class NIST( NIST_Core ):
         debug.debug( "Loading object" )
 
         if isinstance( data, bytes ):
-            data = data.decode( 'utf-8' )
+            data = data.decode( 'latin-1' )
         
         records = data.split( FS )
         
@@ -260,13 +260,13 @@ class NIST( NIST_Core ):
             os.makedirs( os.path.dirname( os.path.realpath( outfile ) ) )
         
         with open( outfile, "wb+" ) as fp:
-            fp.write( self.dumpbin().encode('utf-8') )
+            fp.write( self.dumpbin().encode('latin-1') )
     
     def hash( self ):
 
         dump = self.dumpbin()
         if isinstance( dump, str ):
-            dump = dump.encode('utf-8')
+            dump = dump.encode('latin-1')
 
         return hashlib.md5( dump ).hexdigest()
     

--- a/libs/NIST/readme.rst
+++ b/libs/NIST/readme.rst
@@ -9,4 +9,13 @@ The developpement and maintainance have been made by Marco De Donno, School of C
 
 .. [NIST2013] Data Format for the Interchange of Fingerprint, Facial & Other Biometric Information, NIST Special Publication 500-290 Rev1 (2013), https://www.nist.gov/itl/iad/image-group/ansinist-itl-standard-references
 
+Encoding
+========
+
+Earlier versions of this package decoded all text sections as ``UTF-8``.
+Some real-world NIST files contain byte values outside of that encoding,
+resulting in ``UnicodeDecodeError`` during parsing.  The library now uses
+``latin-1`` when reading, writing or hashing textual fields to preserve
+the original byte content.
+
 

--- a/load_nist.py
+++ b/load_nist.py
@@ -1,6 +1,7 @@
+import os
 from NIST import NIST
 
 if __name__ == '__main__':
-    mynist = NIST(r'amostras\nists\sinpa\120080001610875010220091414.nst')
-
+    sample_path = os.path.join('amostras', 'nists', 'sinpa', '120080001610875010220091414.nst')
+    mynist = NIST(sample_path)
     print(mynist)


### PR DESCRIPTION
## Summary
- decode text fields using latin-1
- write and hash data using latin-1
- fix `load_nist.py` sample path
- document encoding change

## Testing
- `PYTHONPATH=libs/MDmisc:libs/NIST:libs/PMlib:libs/WSQ python load_nist.py`

------
https://chatgpt.com/codex/tasks/task_e_6868240987e88332b879605c90b82a17