### PR TITLE
Convert textual fields to UTF-8 at read time

### DIFF
--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -1083,6 +1083,15 @@ class NIST( object ):
         if self.is_binary( ntype, tagid ) and isinstance( value, str ):
             return value.encode( 'latin-1' )
 
+        # Convert textual fields from the internal latin-1 representation to
+        # UTF-8 when exposing them to callers.  Any invalid byte sequence is
+        # replaced to avoid ``UnicodeDecodeError``.
+        if isinstance( value, str ):
+            try:
+                value = value.encode('latin-1').decode('utf-8')
+            except UnicodeDecodeError:
+                value = value.encode('latin-1').decode('utf-8', 'replace')
+
         return value
     
     def set_field( self, tag, value, idc = -1 ):

--- a/libs/NIST/readme.rst
+++ b/libs/NIST/readme.rst
@@ -24,4 +24,7 @@ internal ``latin-1`` representation automatically.  Accessing these
 fields via ``get_field`` returns the original ``bytes`` object so callers
 no longer need to manually encode or decode the data.
 
+Textual fields retrieved through :func:`get_field` are automatically
+converted from their internal ``latin-1`` representation to ``UTF-8``.
+
 


### PR DESCRIPTION
## Summary
- ensure `NIST.get_field` converts text from latin-1 to UTF-8 when returning a value
- document the new behaviour in the README

## Testing
- `python -m py_compile libs/NIST/NIST/core/__init__.py`
- `python -m py_compile libs/NIST/NIST/traditional/__init__.py`
- *(failed: ModuleNotFoundError: No module named 'PIL' when running runtime example)*

------
https://chatgpt.com/codex/tasks/task_e_68683f94b24c8332887c18f19fb91ea9