### PR TITLE
Fix UTF-8 encoding in NIST.write()

### DIFF
--- a/libs/NIST/NIST/core/__init__.py
+++ b/libs/NIST/NIST/core/__init__.py
@@ -1143,6 +1143,8 @@ class NIST( object ):
 
             if self.is_binary( ntype, tagid ) and isinstance( value, ( bytes, bytearray ) ):
                 value = value.decode( 'latin-1' )
+            elif not self.is_binary( ntype, tagid ) and isinstance( value, ( bytes, bytearray ) ):
+                value = value.decode( 'utf-8' )
 
             if not isinstance( value, str ):
                 value = str( value )

--- a/libs/NIST/readme.rst
+++ b/libs/NIST/readme.rst
@@ -14,9 +14,12 @@ Encoding
 
 Earlier versions of this package decoded all text sections as ``UTF-8``.
 Some real-world NIST files contain byte values outside of that encoding,
-resulting in ``UnicodeDecodeError`` during parsing.  The library now uses
-``latin-1`` when reading, writing or hashing textual fields to preserve
-the original byte content.
+resulting in ``UnicodeDecodeError`` during parsing.  The library originally
+switched to ``latin-1`` for every operation to preserve the raw bytes.
+
+The current version stores textual fields internally as Unicode and
+writes them out using ``UTF-8``.  Binary payloads continue to be handled
+as ``latin-1`` so image data is preserved byte for byte.
 
 Binary payloads such as JPEG or WSQ images can now be passed to
 ``set_field`` directly as ``bytes``.  The library converts them to its


### PR DESCRIPTION
## Summary
- encode text fields as UTF-8 when writing NIST files
- preserve binary fields in latin-1
- update README to mention new encoding behavior

## Testing
- `python -m py_compile libs/NIST/NIST/traditional/__init__.py`
- `python -m py_compile libs/NIST/NIST/core/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68685773900c8332be88baa1563cda90